### PR TITLE
Unit Test for Search API - existing test file

### DIFF
--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -326,3 +326,4 @@ topicsAPI.bookmark = async (caller, { tid }) => {
 	return { message: '[[success:topic-has-been-bookmarked]]' };
 };
 
+module.exports = topicsAPI;

--- a/test/search.js
+++ b/test/search.js
@@ -201,6 +201,22 @@ describe('Search', () => {
 		assert(result.posts[1].topic.title === 'java mongodb redis');
 	});
 
+	it('should search using the new search bar', async () => {
+		// Ensure you use your new search API route or functionality
+		const qs = `/api/search/topics?term=&categories[]=${cid1}`;
+
+		// Send the request to the new search route and get the response
+		const { body } = await request.get(nconf.get('url') + qs);
+
+		// Assert that the response is coming from the new search bar
+		// Example: if your new search returns extra metadata, check for that
+		assert(body);
+		assert.equal(body.matchCount, 1); // Assuming it finds one result
+		assert.equal(body.posts.length, 1);
+		assert.equal(body.posts[0].pid, post1Data.pid); // Ensure the post ID matches
+		assert.equal(body.posts[0].uid, phoebeUid); // Ensure the user ID matches
+	});
+
 	it('should return json search data with no categories', async () => {
 		const qs = '/api/search?term=cucumber&in=titlesposts&searchOnly=1';
 		await privileges.global.give(['groups:search:content'], 'guests');


### PR DESCRIPTION
This PR adds a new test for the new implemented search API in the existing test file. The previous attempts #28 and #30 (both creating new test file) were found with errors.

This is still failing the auto test (with undefined == 1) because I couldn't add topics to the mock database. But the lines were tested with only search (instead search/topics) and passed.

Path: src/test/search.js

Resolves #8 