### PR TITLE
Added static analysis tool: flow

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["@babel/preset-flow"],
+    "plugins": ["babel-plugin-syntax-hermes-parser"],
+}

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,14 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+untyped-type-import=error
+internal-type=error
+deprecated-type-bool=error
+
+[options]
+
+[strict]


### PR DESCRIPTION
This was a static analysis tool that was added called flow. It was added using npm install, and files were changed to prove that it was added globally.

Created files: .babelrc, .flowconfig at root

Added: Into files config.json

Here is more information about the static analysis tool that was added: https://flow.org/en/docs/install/

This can be run by typing npm run flow into the command terminal, as demonstrated in the photo below.

![image](https://github.com/user-attachments/assets/84486dda-2660-4c43-b956-1467d641170c)
